### PR TITLE
HDX-10068 Check for duplicates in paged responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# hdx-hapi-smoke-tests
+
+## Contributions
+
+For developers the code should be cloned installed from the [GitHub repo](https://github.com/OCHA-DAP/hdx-hapi-smoke-tests), and a virtual enviroment created:
+
+```shell
+python -m venv venv
+source venv/Scripts/activate
+```
+
+And then an editable installation created:
+
+```shell
+pip install -r requirements.txt
+```
+
+To run locally the environment variables `BASE URL` and `HAPI_APP_IDENTIFIER` need to be set, the majority of the test suite is generated from a csv file stored as a Google Sheet whose URL is included in the repo but can be overridden with the environment `TEST_SPREADSHEET_URL`.

--- a/test_timestamp_stage.txt
+++ b/test_timestamp_stage.txt
@@ -1,1 +1,1 @@
-The current timestamp is Mon Aug 12 05:18:03 UTC 2024
+The current timestamp is Wed Aug 14 17:33:11 UTC 2024

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -9,29 +9,29 @@ from util.requests import fetch_data_from_hapi
 
 from collections import Counter
 
-# ENDPOINT, Full count (2024-08-13), Country filter, Filtered count
+# ENDPOINT, Country filter, Full count (2024-08-13), Filtered count
 ENDPOINT_ROUTER_LIST = [
-    ("/api/v1/affected-people/refugees", 580074, "HND", 9140),
-    ("/api/v1/affected-people/humanitarian-needs", 279811, "HND", 2589),
-    ("/api/v1/coordination-context/operational-presence", 40472, "", None),
-    ("/api/v1/coordination-context/funding", 434, "", None),
-    ("/api/v1/coordination-context/conflict-event", 1544173, "HTI", 10081),
-    ("/api/v1/coordination-context/national-risk", 26, "", None),
-    ("/api/v1/food/food-security", 119757, "", None),
-    ("/api/v1/food/food-price", 1094401, "HTI", 15948),
-    ("/api/v1/population-social/population", 237100, "", None),
-    ("/api/v1/population-social/poverty-rate", 630, "", None),
-    ("/api/v1/metadata/dataset", 167, "", None),
-    ("/api/v1/metadata/resource", 257, "", None),
-    ("/api/v1/metadata/location", 250, "", None),
-    ("/api/v1/metadata/admin1", 455, "", None),
-    ("/api/v1/metadata/admin2", 5458, "", None),
-    ("/api/v1/metadata/currency", 128, "", None),
-    ("/api/v1/metadata/org", 2531, "", None),
-    ("/api/v1/metadata/org-type", 19, "", None),
-    ("/api/v1/metadata/sector", 20, "", None),
-    ("/api/v1/metadata/wfp-commodity", 1101, "", None),
-    ("/api/v1/metadata/wfp-market", 4141, "", None),
+    ("/api/v1/affected-people/refugees", "HND"),  # , 580074, 9140
+    ("/api/v1/affected-people/humanitarian-needs", "HND"),  # 279811, 2589
+    ("/api/v1/coordination-context/operational-presence", ""),  # 40472,
+    ("/api/v1/coordination-context/funding", ""),  # 434
+    ("/api/v1/coordination-context/conflict-event", "HTI"),  # 1544173, 10081
+    ("/api/v1/coordination-context/national-risk", ""),  # 26,
+    ("/api/v1/food/food-security", ""),  # 119757,
+    ("/api/v1/food/food-price", "HTI"),  # 1094401, 15948
+    ("/api/v1/population-social/population", ""),  # 237100,
+    ("/api/v1/population-social/poverty-rate", ""),  # 630,
+    ("/api/v1/metadata/dataset", ""),  # 167,
+    ("/api/v1/metadata/resource", ""),  # 257,
+    ("/api/v1/metadata/location", ""),  # 250,
+    ("/api/v1/metadata/admin1", ""),  # 455,
+    ("/api/v1/metadata/admin2", ""),  # 5458,
+    ("/api/v1/metadata/currency", ""),  # 128,
+    ("/api/v1/metadata/org", ""),  # 2531,
+    ("/api/v1/metadata/org-type", ""),  # 19,
+    ("/api/v1/metadata/sector", ""),  # 20,
+    ("/api/v1/metadata/wfp-commodity", ""),  # 1101,
+    ("/api/v1/metadata/wfp-market", ""),  # 4141,
 ]
 
 # BASE_URL = BASE_URL.replace("hapi", "hapi-temporary")
@@ -67,13 +67,18 @@ def test_endpoint_list_against_openapi_definition():
 
 
 @pytest.mark.parametrize(
-    "endpoint_router",
+    "endpoint_router, country",
     ENDPOINT_ROUTER_LIST,
-    ids=[x[0][7:] for x in ENDPOINT_ROUTER_LIST],
+    ids=[
+        x[0][7:]
+        for x in ENDPOINT_ROUTER_LIST  # Makes the labels for the parameterized tests
+    ],
 )
-def test_for_duplicates_all_endpoints_parametrically(endpoint_router):
-    theme = endpoint_router[0][1:]
-    country = endpoint_router[2]
+def test_for_duplicates_all_endpoints_parametrically(endpoint_router, country):
+    if BASE_URL.endswith("/"):
+        theme = endpoint_router[0][1:]
+    else:
+        theme = endpoint_router[0]
 
     query_url = (
         f"{BASE_URL}{theme}?"

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -1,3 +1,4 @@
+import pytest
 from util.config import BASE_URL, HAPI_APP_IDENTIFIER
 
 from util.requests import fetch_data_from_hapi
@@ -16,3 +17,80 @@ def test_fetch_data_from_hapi_with_paging():
     results_10000 = fetch_data_from_hapi(query_url, limit=10000)
 
     assert results_1000 == results_10000
+
+
+def test_duplicates_conflict_event_hti_legacy_endpoint():
+    theme = "coordination-context/conflict-event"
+    country = "HTI"
+
+    query_url = (
+        f"{BASE_URL}api/v1/{theme}?"
+        f"output_format=csv"
+        f"&location_code={country}"
+        f"&app_identifier={HAPI_APP_IDENTIFIER}"
+    )
+
+    results = fetch_data_from_hapi(query_url, limit=1000)
+
+    results_set = set(results)
+
+    assert len(results) == len(list(results_set))
+
+
+def test_duplicates_humanitarian_needs_hnd_legacy_endpoint():
+    theme = "affected-people/humanitarian-needs"
+    country = "HND"
+
+    query_url = (
+        f"{BASE_URL}api/v1/{theme}?"
+        f"output_format=csv"
+        f"&location_code={country}"
+        f"&app_identifier={HAPI_APP_IDENTIFIER}"
+    )
+
+    results = fetch_data_from_hapi(query_url, limit=1000)
+
+    results_set = set(results)
+
+    assert len(results) == len(list(results_set))
+
+
+@pytest.mark.xfail
+def test_duplicates_conflict_event_hti_new_endpoint():
+    theme = "coordination-context/conflict-event"
+    country = "HTI"
+
+    base_url = BASE_URL.replace("hapi", "hapi-temporary")
+    query_url = (
+        f"{base_url}api/v1/{theme}?"
+        f"output_format=csv"
+        f"&location_code={country}"
+        f"&app_identifier={HAPI_APP_IDENTIFIER}"
+    )
+
+    results = fetch_data_from_hapi(query_url, limit=1000)
+
+    results_set = set(results)
+
+    assert len(results) == len(list(results_set))
+
+
+@pytest.mark.xfail
+def test_duplicates_humanitarian_needs_hnd_new_endpoint():
+    theme = "affected-people/humanitarian-needs"
+    country = "HND"
+
+    base_url = BASE_URL.replace("hapi", "hapi-temporary")
+
+    query_url = (
+        f"{base_url}api/v1/{theme}?"
+        f"output_format=csv"
+        f"&location_code={country}"
+        f"&app_identifier={HAPI_APP_IDENTIFIER}"
+    )
+
+    results = fetch_data_from_hapi(query_url, limit=1000)
+
+    results_set = set(results)
+
+    assert len(results) == len(list(results_set))

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -1,0 +1,18 @@
+from util.config import BASE_URL, HAPI_APP_IDENTIFIER
+
+from util.requests import fetch_data_from_hapi
+
+
+def test_fetch_data_from_hapi_with_paging():
+    theme = "metadata/admin2"
+
+    query_url = (
+        f"{BASE_URL}api/v1/{theme}?"
+        f"output_format=csv"
+        f"&app_identifier={HAPI_APP_IDENTIFIER}"
+    )
+
+    results_1000 = fetch_data_from_hapi(query_url, limit=1000)
+    results_10000 = fetch_data_from_hapi(query_url, limit=10000)
+
+    assert results_1000 == results_10000

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -7,6 +7,31 @@ from util.config import BASE_URL, HAPI_APP_IDENTIFIER
 
 from util.requests import fetch_data_from_hapi
 
+# ENDPOINT, Full count (2024-08-13), Country filter, Filtered count
+ENDPOINT_ROUTER_LIST = [
+    ("/api/v1/affected-people/refugees", 580074, "HND", 9140),
+    ("/api/v1/affected-people/humanitarian-needs", 279811, "HND", 2589),
+    ("/api/v1/coordination-context/operational-presence", 40472, "", None),
+    ("/api/v1/coordination-context/funding", 434, "", None),
+    ("/api/v1/coordination-context/conflict-event", 1544173, "HTI", 10081),
+    ("/api/v1/coordination-context/national-risk", 26, "", None),
+    ("/api/v1/food/food-security", 119757, "", None),
+    ("/api/v1/food/food-price", 1094401, "HTI", 15948),
+    ("/api/v1/population-social/population", 237100, "", None),
+    ("/api/v1/population-social/poverty-rate", 630, "", None),
+    ("/api/v1/metadata/dataset", 167, "", None),
+    ("/api/v1/metadata/resource", 257, "", None),
+    ("/api/v1/metadata/location", 250, "", None),
+    ("/api/v1/metadata/admin1", 455, "", None),
+    ("/api/v1/metadata/admin2", 5458, "", None),
+    ("/api/v1/metadata/currency", 128, "", None),
+    ("/api/v1/metadata/org", 2531, "", None),
+    ("/api/v1/metadata/org-type", 19, "", None),
+    ("/api/v1/metadata/sector", 20, "", None),
+    ("/api/v1/metadata/wfp-commodity", 1101, "", None),
+    ("/api/v1/metadata/wfp-market", 4141, "", None),
+]
+
 
 def test_fetch_data_from_hapi_with_paging():
     theme = "metadata/admin2"
@@ -100,33 +125,7 @@ def test_duplicates_humanitarian_needs_hnd_new_endpoint():
     assert len(results) == len(list(results_set))
 
 
-# ENDPOINT, Full count (2024-08-13), Country filter, Filtered count
-ENDPOINT_ROUTER_LIST = [
-    ("/api/v1/affected-people/refugees", 580074, "HND", 9140),
-    ("/api/v1/affected-people/humanitarian-needs", 279811, "HND", 2589),
-    ("/api/v1/coordination-context/operational-presence", 40472, "", None),
-    ("/api/v1/coordination-context/funding", 431, "", None),
-    ("/api/v1/coordination-context/conflict-event", 1544173, "HTI", 10081),
-    ("/api/v1/coordination-context/national-risk", 26, "", None),
-    ("/api/v1/food/food-security", 119876, "", None),
-    ("/api/v1/food/food-price", 1094401, "HTI", 15948),
-    ("/api/v1/population-social/population", 237337, "", None),
-    ("/api/v1/population-social/poverty-rate", 630, "", None),
-    ("/api/v1/metadata/dataset", 167, "", None),
-    ("/api/v1/metadata/resource", 257, "", None),
-    ("/api/v1/metadata/location", 250, "", None),
-    ("/api/v1/metadata/admin1", 455, "", None),
-    ("/api/v1/metadata/admin2", 5458, "", None),
-    ("/api/v1/metadata/currency", 128, "", None),
-    ("/api/v1/metadata/org", 2531, "", None),
-    ("/api/v1/metadata/org-type", 19, "", None),
-    ("/api/v1/metadata/sector", 20, "", None),
-    ("/api/v1/metadata/wfp-commodity", 1101, "", None),
-    ("/api/v1/metadata/wfp-market", 4144, "", None),
-]
-
-
-def test_endpoint_list():
+def test_endpoint_list_against_openapi_definition():
     with request.urlopen(f"{BASE_URL}/openapi.json") as openapi_json_url:
         openapi_json = json.load(openapi_json_url)
 
@@ -139,6 +138,27 @@ def test_endpoint_list():
     assert endpoint_paths == openapi_paths
 
 
-@pytest.mark.parametrize("endpoint_router", ENDPOINT_ROUTER_LIST)
-def test_for_duplicates(endpoint_router):
-    pass
+@pytest.mark.parametrize(
+    "endpoint_router",
+    ENDPOINT_ROUTER_LIST,
+    ids=[x[0][7:] for x in ENDPOINT_ROUTER_LIST],
+)
+def test_for_duplicates_all_endpoints_parametrically(endpoint_router):
+    theme = endpoint_router[0][1:]
+    country = endpoint_router[2]
+
+    query_url = (
+        f"{BASE_URL}{theme}?"
+        f"output_format=csv"
+        f"&location_code={country}"
+        f"&app_identifier={HAPI_APP_IDENTIFIER}"
+    )
+
+    if "refugees" in query_url:
+        query_url = query_url.replace("location_code", "origin_location_code")
+
+    results = fetch_data_from_hapi(query_url, limit=1000)
+
+    results_set = set(results)
+
+    assert len(results) == len(list(results_set))

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -1,4 +1,8 @@
+import json
 import pytest
+
+from urllib import request
+
 from util.config import BASE_URL, HAPI_APP_IDENTIFIER
 
 from util.requests import fetch_data_from_hapi
@@ -94,3 +98,47 @@ def test_duplicates_humanitarian_needs_hnd_new_endpoint():
     results_set = set(results)
 
     assert len(results) == len(list(results_set))
+
+
+# ENDPOINT, Full count (2024-08-13), Country filter, Filtered count
+ENDPOINT_ROUTER_LIST = [
+    ("/api/v1/affected-people/refugees", 580074, "HND", 9140),
+    ("/api/v1/affected-people/humanitarian-needs", 279811, "HND", 2589),
+    ("/api/v1/coordination-context/operational-presence", 40472, "", None),
+    ("/api/v1/coordination-context/funding", 431, "", None),
+    ("/api/v1/coordination-context/conflict-event", 1544173, "HTI", 10081),
+    ("/api/v1/coordination-context/national-risk", 26, "", None),
+    ("/api/v1/food/food-security", 119876, "", None),
+    ("/api/v1/food/food-price", 1094401, "HTI", 15948),
+    ("/api/v1/population-social/population", 237337, "", None),
+    ("/api/v1/population-social/poverty-rate", 630, "", None),
+    ("/api/v1/metadata/dataset", 167, "", None),
+    ("/api/v1/metadata/resource", 257, "", None),
+    ("/api/v1/metadata/location", 250, "", None),
+    ("/api/v1/metadata/admin1", 455, "", None),
+    ("/api/v1/metadata/admin2", 5458, "", None),
+    ("/api/v1/metadata/currency", 128, "", None),
+    ("/api/v1/metadata/org", 2531, "", None),
+    ("/api/v1/metadata/org-type", 19, "", None),
+    ("/api/v1/metadata/sector", 20, "", None),
+    ("/api/v1/metadata/wfp-commodity", 1101, "", None),
+    ("/api/v1/metadata/wfp-market", 4144, "", None),
+]
+
+
+def test_endpoint_list():
+    with request.urlopen(f"{BASE_URL}/openapi.json") as openapi_json_url:
+        openapi_json = json.load(openapi_json_url)
+
+    openapi_paths = set(list(openapi_json["paths"].keys()))
+    openapi_paths.remove("/api/v1/encode_app_identifier")
+    openapi_paths.remove("/api/v1/util/version")
+
+    endpoint_paths = {x[0] for x in ENDPOINT_ROUTER_LIST}
+
+    assert endpoint_paths == openapi_paths
+
+
+@pytest.mark.parametrize("endpoint_router", ENDPOINT_ROUTER_LIST)
+def test_for_duplicates(endpoint_router):
+    pass

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,39 +2,55 @@ from io import StringIO
 import requests
 import pytest
 import csv
-from util.config import BASE_URL, TESTS_SPREADSHEET_URL, HEADER_API_CALL, HEADER_RULES, HEADER_DESCRIPTION, \
-    HEADER_ENABLED, HAPI_APP_IDENTIFIER
+from util.config import (
+    BASE_URL,
+    TESTS_SPREADSHEET_URL,
+    HEADER_API_CALL,
+    HEADER_RULES,
+    HEADER_DESCRIPTION,
+    HEADER_ENABLED,
+    HAPI_APP_IDENTIFIER,
+)
 
 from util.requests import download_csv, read_data_from_csv
 from util.rules import parse_rules
 
 download_csv(TESTS_SPREADSHEET_URL, "tests.csv")
 data_all_columns = read_data_from_csv("tests.csv")
-data = [[row[HEADER_DESCRIPTION], row] for row in data_all_columns if row[HEADER_ENABLED] == 'TRUE']
+data = [
+    [row[HEADER_DESCRIPTION], row]
+    for row in data_all_columns
+    if row[HEADER_ENABLED] == "TRUE"
+]
 
 
 @pytest.mark.parametrize("description, test_info", data)
 def test_json_rest_api(description, test_info):
     rules = parse_rules(test_info[HEADER_RULES])
 
-    relative_url = test_info[HEADER_API_CALL][1:] if test_info[HEADER_API_CALL].startswith('/') else test_info[
-        HEADER_API_CALL]
+    relative_url = (
+        test_info[HEADER_API_CALL][1:]
+        if test_info[HEADER_API_CALL].startswith("/")
+        else test_info[HEADER_API_CALL]
+    )
 
-    if '?' in relative_url:
-        relative_url += f'&app_identifier={HAPI_APP_IDENTIFIER}'
+    if "?" in relative_url:
+        relative_url += f"&app_identifier={HAPI_APP_IDENTIFIER}"
     else:
-        relative_url += f'?app_identifier={HAPI_APP_IDENTIFIER}'
-    endpoint_url = f'{BASE_URL}{relative_url}'
+        relative_url += f"?app_identifier={HAPI_APP_IDENTIFIER}"
+    endpoint_url = f"{BASE_URL}{relative_url}"
 
     response = requests.get(endpoint_url)
     response_dict = response.json()
-    object_list = response_dict.get('data',[])
+    object_list = response_dict.get("data", [])
 
     assert response.status_code == 200, ", url:" + endpoint_url
 
     for rule in rules:
         output_description = rule.description + ", url:" + endpoint_url
-        assert rule.operator(rule.input_list_builder(object_list), rule.value), output_description
+        assert rule.operator(
+            rule.input_list_builder(object_list), rule.value
+        ), output_description
         # for debug
         # result = rule.operator(rule.input_list_builder(object_list), rule.value)
         # if result:
@@ -43,10 +59,9 @@ def test_json_rest_api(description, test_info):
         #     assert True
 
 
-
-
 def test_csv_rest_api():
-    endpoint_url = f'{BASE_URL}api/v1/metadata/dataset?output_format=csv&app_identifier={HAPI_APP_IDENTIFIER}'
+    endpoint_url = f"{BASE_URL}api/v1/metadata/dataset?output_format=csv&app_identifier={HAPI_APP_IDENTIFIER}"
+    print(endpoint_url, flush=True)
     response = requests.get(endpoint_url)
 
     assert response.status_code == 200
@@ -58,4 +73,3 @@ def test_csv_rest_api():
     csv_rows = list(csv_reader)
 
     assert len(csv_rows) > 2
-

--- a/util/requests.py
+++ b/util/requests.py
@@ -1,23 +1,84 @@
 import csv
+import json
 import requests
+import time
+from urllib import request
+
 
 def download_csv(url: str, path: str):
-    '''
+    """
     Download a CSV file from the given URL and save it to the given path
-    '''
+    """
     response = requests.get(url, timeout=50)
     with open(path, "wb") as mapping_file:
         mapping_file.write(response.content)
 
 
 def read_data_from_csv(csv_file_path):
-    '''
+    """
     Read data from a CSV file and return the header and data rows
-    '''
+    """
     data = []
-    with open(csv_file_path, 'r') as csv_file:
+    with open(csv_file_path, "r") as csv_file:
         reader = csv.DictReader(csv_file)
-        
+
         for row in reader:
             data.append(row)
     return data
+
+
+def fetch_data_from_hapi(query_url, limit=1000):
+    """
+    Fetch data from the provided query_url with pagination support.
+
+    Args:
+    - query_url (str): The query URL to fetch data from.
+    - limit (int): The number of records to fetch per request.
+
+    Returns:
+    - list: A list of fetched results.
+    """
+
+    if "encode_app_identifier" in query_url:
+        with request.urlopen(query_url) as response:
+            json_response = json.loads(response.read())
+
+        return json_response
+
+    idx = 0
+    results = []
+
+    t0 = time.time()
+    while True:
+        offset = idx * limit
+        url = f"{query_url}&offset={offset}&limit={limit}"
+
+        with request.urlopen(url) as response:
+            print(f"Getting results {offset} to {offset+limit-1}")
+            print(f"{url}", flush=True)
+            encoding = response.headers.get_content_charset()
+
+            # print(response.headers, flush=True)
+            if "output_format=json" in query_url:
+                json_response = json.loads(response.read())
+
+                results.extend(json_response["data"])
+                # If the returned results are less than the limit,
+                # it's the last page
+                if len(json_response["data"]) < limit:
+                    break
+            else:
+                raw = response.read().decode(encoding)
+                csv_rows = raw.splitlines()
+                # Don't include the header line except for the first file
+                if len(results) == 0:
+                    results.extend(csv_rows)
+                else:
+                    results.extend(csv_rows[1:])
+
+                if len(csv_rows) < limit:
+                    break
+        idx += 1
+
+    print(f"Download took {time.time()-t0:0.2f} seconds", flush=True)
+    return results


### PR DESCRIPTION
This PR adds some tests of paginated results, additionally it adds a test for the paging mechanism itself and a test that the parameterized tests cover all of the required endpoints by checking against the paths in `openapi.json`. For most endpoints the tests attempt to load all the data but for some it is necessary to use a subset of the data - typically obtained by filtering to one country (HTI or HND).

As of writing (2024-08-14) the tests find duplicate rows for the following endpoints in `hapi-temporary`:
1. affected-people/refugees
2. affected-people/humanitarian-needs
3. coordination-context/conflict-events
4. food/food-price

The `hapi` endpoint passes all tests (although there are intermittent 500 errors)

The tests against `hapi-temporary` run in approximately 10 minutes, whilst against `hapi` they take approximately 2.5 minutes.


