### PR TITLE
HDX-10194 Update HAPI smoke tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 venv/
-tests.csv
+# tests.csv
 __pycache__/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,9 @@
         "editor.formatOnSave": true,
         "editor.defaultFormatter": "charliermarsh.ruff"
     },
+    "flake8.args": [
+        "--config=pyproject.toml",
+    ],
     "ruff.enable": true,
     "ruff.importStrategy": "fromEnvironment",
     "ruff.lint.args": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,24 @@
 {
+    "editor.rulers": [
+        120
+    ],
+    "[python]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "charliermarsh.ruff"
+    },
+    "ruff.enable": true,
+    "ruff.importStrategy": "fromEnvironment",
+    "ruff.lint.args": [
+        "--config=pyproject.toml", 
+    ],
+    "ruff.format.args": [
+        "--config=pyproject.toml",
+    ],
+    "python.analysis.autoImportCompletions": true,
     "python.testing.pytestArgs": [
         "tests"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "python.analysis.typeCheckingMode": "standard",
 }

--- a/README.md
+++ b/README.md
@@ -16,3 +16,16 @@ pip install -r requirements.txt
 ```
 
 To run locally the environment variables `BASE URL` and `HAPI_APP_IDENTIFIER` need to be set, the majority of the test suite is generated from a csv file stored as a Google Sheet whose URL is included in the repo but can be overridden with the environment `TEST_SPREADSHEET_URL`.
+
+The spreadsheet has the following columns, those marked * are used by the smoke test code in this repo:
+
+* location
+* Test ID
+* Description*
+* Args [NOT USED]
+* API call*
+* \# of results expected
+* Expected in each result object [NOT USED]
+* Priority
+* Implemented?*
+* Rules*

--- a/README.md
+++ b/README.md
@@ -29,3 +29,9 @@ The spreadsheet has the following columns, those marked * are used by the smoke 
 * Priority
 * Implemented?*
 * Rules*
+
+For local testing the easiest way to override the target HAPI instance is by editing the default value in this line in `util/config.py` and ensuring `BASE_URL` is not defined as an environment variable:
+
+```python
+BASE_URL = os.getenv('BASE_URL', 'https://stage.hapi-humdata-org.ahconu.org/')
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[tool.ruff]
+# Allow lines to be as long as 120 characters.
+line-length = 120
+
+[tool.ruff.lint]
+select = [
+    "E", 
+    "F", 
+    "Q", 
+    "INP001", # Checks for packages that are missing an __init__.py file.
+]
+
+[tool.ruff.lint.flake8-quotes]
+inline-quotes = "single"
+multiline-quotes = "single"
+
+[tool.ruff.format]
+# Prefer single quotes over double quotes
+quote-style = "single"
+
+
+[tool.black]
+line-length = 120
+skip-string-normalization = true

--- a/test_timestamp_stage.txt
+++ b/test_timestamp_stage.txt
@@ -1,1 +1,1 @@
-The current timestamp is Sun Sep 29 19:45:39 UTC 2024
+The current timestamp is Mon Sep 30 05:40:00 UTC 2024

--- a/test_timestamp_stage.txt
+++ b/test_timestamp_stage.txt
@@ -1,1 +1,1 @@
-The current timestamp is Thu Sep 12 05:18:12 UTC 2024
+The current timestamp is Sun Sep 29 19:45:39 UTC 2024

--- a/tests.csv
+++ b/tests.csv
@@ -1,4 +1,4 @@
-location,Test ID,Description,Args,API call,# of results expected,Expected in each result object,Priority,Implemented?,Rules,Notes
+location,Test ID,Description,Args [NOT USED],API call,# of results expected,Expected in each result object [NOT USED],Priority,Implemented?,Rules,Notes
 refugees,ref-default,List of refugees,,/api/v1/affected-people/refugees,full page,"origin_location_code not null
 origin_location_name not null
 asylum_location_code not null
@@ -374,8 +374,13 @@ name=""United States dollar""",FALSE,TRUE,"TOTAL_COUNT=1;
 ALL_HAVE_PROPERTIES[code, name];
 ALL_VERIFY_COMPARISON[code=""USD""];
 ALL_VERIFY_COMPARISON[name=""United States Dollar""];",also tests case-insensitivity
-admin1,,,,,,,FALSE,FALSE,,
-,,,,,,,FALSE,FALSE,,
+data-availability,dat-default,List of data-availability,,/api/v1/metadata/data-availability,full page,,FALSE,TRUE,"TOTAL_COUNT>50; 
+ALL_HAVE_PROPERTIES[category, subcategory, location_code, location_name,  hapi_updated_date];",
+data-availability,dat-filtered,List of filtered data-availability,,/api/v1/metadata/data-availability?subcategory=refugees&location_code=AFG,1,,FALSE,TRUE,"TOTAL_COUNT = 1; 
+ALL_HAVE_PROPERTIES[category, subcategory, location_code, location_name,  hapi_updated_date];
+ALL_VERIFY_COMPARISON[category=""affected-people""]; 
+ALL_VERIFY_COMPARISON[location_code=""AFG""];
+ALL_VERIFY_COMPARIONS[subcategory=""refugees];",
 ,,,,,,,FALSE,FALSE,,
 ,,,,,,,FALSE,FALSE,,
 ,,,,,,,FALSE,FALSE,,

--- a/tests.csv
+++ b/tests.csv
@@ -380,7 +380,7 @@ data-availability,dat-filtered,List of filtered data-availability,,/api/v1/metad
 ALL_HAVE_PROPERTIES[category, subcategory, location_code, location_name,  hapi_updated_date];
 ALL_VERIFY_COMPARISON[category=""affected-people""]; 
 ALL_VERIFY_COMPARISON[location_code=""AFG""];
-ALL_VERIFY_COMPARIONS[subcategory=""refugees];",
+ALL_VERIFY_COMPARIONS[subcategory=""refugees""];",
 ,,,,,,,FALSE,FALSE,,
 ,,,,,,,FALSE,FALSE,,
 ,,,,,,,FALSE,FALSE,,

--- a/tests.csv
+++ b/tests.csv
@@ -380,7 +380,7 @@ data-availability,dat-filtered,List of filtered data-availability,,/api/v1/metad
 ALL_HAVE_PROPERTIES[category, subcategory, location_code, location_name,  hapi_updated_date];
 ALL_VERIFY_COMPARISON[category=""affected-people""]; 
 ALL_VERIFY_COMPARISON[location_code=""AFG""];
-ALL_VERIFY_COMPARIONS[subcategory=""refugees""];",
+ALL_VERIFY_COMPARISON[subcategory=""refugees""];",
 ,,,,,,,FALSE,FALSE,,
 ,,,,,,,FALSE,FALSE,,
 ,,,,,,,FALSE,FALSE,,

--- a/tests.csv
+++ b/tests.csv
@@ -1,0 +1,1307 @@
+location,Test ID,Description,Args,API call,# of results expected,Expected in each result object,Priority,Implemented?,Rules,Notes
+refugees,ref-default,List of refugees,,/api/v1/affected-people/refugees,full page,"origin_location_code not null
+origin_location_name not null
+asylum_location_code not null
+asylum_location_name not null
+resource_hdx_id not null
+reference_period_start not null",TRUE,TRUE,"TOTAL_COUNT>50; 
+ALL_HAVE_PROPERTIES[resource_hdx_id, origin_location_code, origin_location_name, asylum_location_code, asylum_location_name, reference_period_start]; ",
+refugees,ref-filtered,List of filtered refugees,?origin_location_code=SSD&asylum_location_code=UGA&population_group=ASY&gender=all&age_range=all,/api/v1/affected-people/refugees?origin_location_code=SSD&asylum_location_code=UGA&population_group=ASY&gender=all&age_range=all,full page,"origin_location_code not null
+origin_location_name not null
+asylum_location_code not null
+asylum_location_name not null
+population_group=""ASY""
+gender=""all""
+age_range=""all""
+population > 0
+",FALSE,TRUE,"TOTAL_COUNT>0; 
+ALL_HAVE_PROPERTIES[origin_location_code, origin_location_name, asylum_location_code, asylum_location_name]; 
+ALL_VERIFY_COMPARISON[population_group=""ASY""];
+ALL_VERIFY_COMPARISON[gender=""all""];
+ALL_VERIFY_COMPARISON[age_range=""all""];
+ALL_VERIFY_COMPARISON[population>0];","There are lots of refugees in Uganda from South Sudan, so this should safely give us non-zero results."
+returnees,ret-default,List of returnees,,/api/v1/affected-people/returnees,full page,"origin_location_code not null
+origin_location_name not null
+asylum_location_code not null
+asylum_location_name not null
+resource_hdx_id not null
+reference_period_start not null",FALSE,TRUE,"TOTAL_COUNT>50; 
+ALL_HAVE_PROPERTIES[resource_hdx_id, origin_location_code, origin_location_name, asylum_location_code, asylum_location_name, reference_period_start]; ",
+returnees,ret-filtered,List of filtered returnees,,/api/v1/affected-people/returnees?population_group=RET&gender=all&age_range=all&origin_location_code=SSD,full page,"origin_location_code not null
+origin_location_name not null
+asylum_location_code not null
+asylum_location_name not null
+population_group=""RET""
+gender=""all""
+age_range=""all""
+population > 0
+",FALSE,TRUE,"TOTAL_COUNT>0; 
+ALL_HAVE_PROPERTIES[origin_location_code, origin_location_name, asylum_location_code, asylum_location_name]; 
+ALL_VERIFY_COMPARISON[population_group=""RET""];
+ALL_VERIFY_COMPARISON[gender=""all""];
+ALL_VERIFY_COMPARISON[age_range=""all""];
+ALL_VERIFY_COMPARISON[population>0];",
+idps,idp-default,List of idps,,/api/v1/affected-people/idps,full page,,FALSE,TRUE,"TOTAL_COUNT>50; 
+ALL_HAVE_PROPERTIES[resource_hdx_id, location_code, location_name, resource_hdx_id, assessment_type, reference_period_start]; ",
+idps,idp-filtered,List of filtered idps,,/api/v1/affected-people/idps?location_code=AFG,full page,,FALSE,TRUE,"TOTAL_COUNT>50; 
+ALL_HAVE_PROPERTIES[resource_hdx_id, location_code, location_name, resource_hdx_id, assessment_type, reference_period_start];
+ALL_VERIFY_COMPARISON[location_code=""AFG""];",
+humanitarian-needs,hn-default,List of humanitarian needs,,/api/v1/affected-people/humanitarian-needs,full page,"location_code not null
+location_name not null
+sector_code not null
+resource_hdx_id not null
+reference_period_start not null",TRUE,TRUE,"TOTAL_COUNT>50; 
+ALL_HAVE_PROPERTIES[location_code, location_name, sector_code, resource_hdx_id, reference_period_start];",
+humanitarian-needs,hn-filtered,filtered list of hum needs,?admin2_code=YE2901&gender=f&sector_code=HEA&population_status=INN,/api/v1/affected-people/humanitarian-needs?admin2_code=YE2901&gender=f&sector_code=HEA&population_status=INN,3,"location_code=""YEM""
+admin1_code=""YE29""
+admin2_code=""YE2901""
+population_group=""all""
+population_status=""inneed""
+population > 0",FALSE,TRUE,"TOTAL_COUNT>1; 
+ALL_HAVE_PROPERTIES[location_code, location_name, sector_code, resource_hdx_id, reference_period_start]; 
+ALL_VERIFY_COMPARISON[location_code=""YEM""];
+ALL_VERIFY_COMPARISON[admin1_code=""YE29""];
+ALL_VERIFY_COMPARISON[admin2_code=""YE2901""];
+ALL_VERIFY_COMPARISON[population_group=""all""];
+ALL_VERIFY_COMPARISON[population_status=""INN""];
+ALL_VERIFY_COMPARISON[population>0];","There should be two age ranges and ""all"", according to the source data. 
+
+The Yemen HNO doesn't disaggregate by population_group. 
+"
+operational-presence,op-default,list of operational presence,,/api/v1/coordination-context/operational-presence,full page,"location_code not null
+location_name not null
+sector_code not null
+org_name not null
+resource_hdx_id not null
+reference_period_start not null",TRUE,TRUE,"TOTAL_COUNT>50; 
+ALL_HAVE_PROPERTIES[location_code, location_name, sector_code, org_name, resource_hdx_id, reference_period_start]; ",
+operational-presence,op-filtered,filtered list of operational presence,?org_acronym=CRS&sector_code=SHL&admin2_code=HT1024,/api/v1/coordination-context/operational-presence?org_acronym=CRS&sector_code=SHL&admin2_code=HT1024,>= 1,"org_acronym=""CRS""
+org_name=""Catholic Relief Services""
+org_type_code=""437""
+org_type_description=""International NGO""
+sector_code=""SHL""
+sector_name=""Emergency Shelter and NFI""
+location_code=""HTI""
+location_name=""Haiti""
+admin1_code=""HT10""
+admin1_name=""Nip""
+admin2_code=""HT1024""
+admin2_name=""Arnaud""
+reference_period_start > 2020-01-01",FALSE,TRUE,"TOTAL_COUNT>0; 
+ALL_HAVE_PROPERTIES[location_code, location_name, sector_code, org_name, resource_hdx_id, reference_period_start];
+ALL_VERIFY_COMPARISON[org_acronym=""CRS""];
+ALL_VERIFY_COMPARISON[org_name=""Catholic Relief Services""];
+ALL_VERIFY_COMPARISON[org_type_code=""437""];
+ALL_VERIFY_COMPARISON[sector_code=""SHL""];
+ALL_VERIFY_COMPARISON[sector_name=""Emergency Shelter and NFI""];
+ALL_VERIFY_COMPARISON[location_code=""HTI""];
+ALL_VERIFY_COMPARISON[location_name=""Haiti""];
+ALL_VERIFY_COMPARISON[admin1_code=""HT10""];
+ALL_VERIFY_COMPARISON[admin1_name=""Nippes""];
+ALL_VERIFY_COMPARISON[admin2_code=""HT1024""];
+ALL_VERIFY_COMPARISON[admin2_name=""Arnaud""];","Assuming we're not backdating before 2020
+
+This also tests admin-level names"
+funding,fund-default,list of fundings,,/api/v1/coordination-context/funding,full page,"location_code not null
+location_name not null
+appeal_code not null
+requirements_usd > 0
+resource_hdx_id not null
+reference_period_start not null",TRUE,TRUE,"TOTAL_COUNT>50; 
+ALL_HAVE_PROPERTIES[location_code, location_name, appeal_code, resource_hdx_id, reference_period_start];
+ALL_VERIFY_COMPARISON[requirements_usd>=0];",
+funding,fund-filtered,list of fundings by location and appeal code,"?location_code=AFG&appeal_code=""HAFG24""",/api/v1/coordination-context/funding?location_code=AFG&appeal_code=HAFG24,1,"location_code=""AFG""
+appeal_code=""HAFG24""
+requirements_usd >= 1,000,000,000
+funding_usd >= 100,000,000
+funding_pct >= 10
+reference_period_start >= ""2024-01-01""
+reference_period_end < ""2025-01-01""",FALSE,TRUE,"TOTAL_COUNT>0; 
+ALL_HAVE_PROPERTIES[location_code, location_name, appeal_code, resource_hdx_id, reference_period_start];
+ALL_VERIFY_COMPARISON[location_code=""AFG""];
+ALL_VERIFY_COMPARISON[appeal_code=""HAFG24""];
+ALL_VERIFY_COMPARISON[requirements_usd>=1000000000];
+ALL_VERIFY_COMPARISON[funding_usd>=100000000];
+ALL_VERIFY_COMPARISON[funding_pct>=10];",Assuming funding won't decrease excessively over the rest of 2024.
+conflict-event,ce-default,list of conflict events,,/api/v1/coordination-context/conflict-event,full page,"location_code not null
+location_name not null
+event_type not null
+resource_hdx_id not null
+reference_period_start not null",TRUE,TRUE,"TOTAL_COUNT>50; 
+ALL_HAVE_PROPERTIES[location_code, location_name, event_type, resource_hdx_id, reference_period_start];",
+conflict-event,ce-filtered,list of conflict events by location code,?location_code=TCD,/api/v1/coordination-context/conflict-event?location_code=TCD,>1,"location_code=""TCD""
+location_name=""Chad""
+events >= 0 OR fatalities >= 0",FALSE,FALSE,"TOTAL_COUNT>1; 
+ALL_HAVE_PROPERTIES[location_code, location_name, event_type, resource_hdx_id, reference_period_start];
+ALL_VERIFY_COMPARISON[location_code=""TCD""];
+ALL_VERIFY_COMPARISON[location_name=""Chad""];
+ALL_VERIFY_COMPARISON[events>=0];
+ALL_VERIFY_COMPARISON[fatalities>=0];",
+national-risk,nr-default,list of national risks,,/api/v1/coordination-context/national-risk,full page,"location_code not null
+location_name not null
+risk_class not null
+global_rank in range 1,250
+resource_hdx_id not null
+reference_period_start not null",TRUE,TRUE,"TOTAL_COUNT>20; 
+ALL_HAVE_PROPERTIES[location_code, location_name, risk_class, resource_hdx_id, reference_period_start];
+ALL_VERIFY_COMPARISON[global_rank>0];
+ALL_VERIFY_COMPARISON[global_rank<250];",
+national-risk,nr-filtered,list of national risks by code,?location_code=PSE,/api/v1/coordination-context/national-risk?location_code=PSE,1,"location_code=""PSE""
+risk_class in range 1..5
+global_rank in range 1..250
+overall_risk in range 0.0..10.0
+hazard_exposure_risk in range 0.0..10.0
+vulnerability_risk in range 0.0..10.0
+coping_capacity_risk in range 0.0..10.0
+reference_period_start>=""2024-01-01""
+reference_period_end<""2025-01-01""",FALSE,TRUE,"TOTAL_COUNT>0; 
+ALL_HAVE_PROPERTIES[location_code, location_name, risk_class, resource_hdx_id, reference_period_start];
+ALL_VERIFY_COMPARISON[location_code=""PSE""];
+ALL_VERIFY_COMPARISON[global_rank>1];
+ALL_VERIFY_COMPARISON[global_rank<250];
+ALL_VERIFY_COMPARISON[risk_class=""3""];
+ALL_VERIFY_COMPARISON[overall_risk>0];
+ALL_VERIFY_COMPARISON[overall_risk<10];
+ALL_VERIFY_COMPARISON[hazard_exposure_risk>0];
+ALL_VERIFY_COMPARISON[hazard_exposure_risk<10];
+ALL_VERIFY_COMPARISON[vulnerability_risk>0];
+ALL_VERIFY_COMPARISON[vulnerability_risk<10];
+ALL_VERIFY_COMPARISON[coping_capacity_risk>0];
+ALL_VERIFY_COMPARISON[coping_capacity_risk<10];",
+food-security,fs-default,list of food security records,,/api/v1/food/food-security,full page,"location_code not null
+location_name not null
+ipc_phase not null
+ipc_type not null
+population_in_phase >= 0
+resource_hdx_id not null
+reference_period_start not null",TRUE,TRUE,"TOTAL_COUNT>50; 
+ALL_HAVE_PROPERTIES[location_code, location_name, ipc_phase, ipc_type, resource_hdx_id, reference_period_start];
+ALL_VERIFY_COMPARISON[population_in_phase>=0];",
+food-security,fs-filtered,list of food security records by admin1 code and ipc type,?admin1_code=NE008&ipc_phase=3&ipc_type=current,/api/v1/food/food-security?admin1_code=NE008&ipc_phase=3&ipc_type=current,>=1,"location_code=""BGD""
+admin1_code=""BD55""
+admin1_name=""Rangpur""
+ipc_phase=""3""
+ipc_type=""current""
+population_in_phase>0
+population_fraction_in_phase > 0.0",FALSE,TRUE,"TOTAL_COUNT>0; 
+ALL_HAVE_PROPERTIES[location_code, location_name, ipc_phase, ipc_type, resource_hdx_id, reference_period_start];
+ALL_VERIFY_COMPARISON[population_in_phase>=0];
+ALL_VERIFY_COMPARISON[location_code=""NER""];
+ALL_VERIFY_COMPARISON[admin1_code=""NE008""];
+ALL_VERIFY_COMPARISON[admin1_name=""Niamey""];
+ALL_VERIFY_COMPARISON[ipc_phase=""3""];
+ALL_VERIFY_COMPARISON[ipc_type=""current""];
+ALL_VERIFY_COMPARISON[population_fraction_in_phase>=0];",Also tests admin1_name from CODs
+food-price,fp-default,list of food prices,,/api/v1/food/food-price,full page,"location_code not null
+location_name not null
+currency_code not null
+price >= 0
+resource_hdx_id not null
+reference_period_start not null",TRUE,TRUE,"TOTAL_COUNT>50; 
+ALL_HAVE_PROPERTIES[location_code, location_name, currency_code, resource_hdx_id, reference_period_start];
+ALL_VERIFY_COMPARISON[price>=0];",
+food-price,fp-filtered,list of food prices by country code,?location_code=ETH,/api/v1/food/food-price?location_code=ETH,full page,"location_code=""ETH""
+lat in range 3.0..15.0
+lon in range 33..48
+market_code not null
+market_name not null
+commodity_code not null
+commodity_name not null
+commodity_category not null
+currency_code=""ETB""
+unit not null
+price_flag not null
+price_type not null
+price >= 0.0",FALSE,TRUE,"TOTAL_COUNT>50; 
+ALL_HAVE_PROPERTIES[location_code, location_name, currency_code, resource_hdx_id, reference_period_start, market_code, market_name, commodity_code, commodity_name, commodity_category, unit, price_flag, price_type];
+ALL_VERIFY_COMPARISON[price>=0];
+ALL_VERIFY_COMPARISON[location_code=""ETH""];
+ALL_VERIFY_COMPARISON[currency_code=""ETB""];
+ALL_VERIFY_COMPARISON[lat>3];
+ALL_VERIFY_COMPARISON[lat<15];
+ALL_VERIFY_COMPARISON[lon>33];
+ALL_VERIFY_COMPARISON[lon<48];","Assumption that all prices are in ETB might be wrong.
+
+latlon bounding box might be too tight"
+population,pop-default,list of population records,,/api/v1/population-social/population,full page,"location_code not null
+location_name not null
+gender not null
+age_range not null
+population >= 0
+resource_hdx_id not null
+reference_period_start not null",TRUE,TRUE,"TOTAL_COUNT>50; 
+ALL_HAVE_PROPERTIES[location_code, location_name, gender, age_range, resource_hdx_id, reference_period_start];
+ALL_VERIFY_COMPARISON[population>=0];",
+population,pop-filtered,list of population by admin1 code,?admin1_code=SD18,/api/v1/population-social/population?admin1_code=SD18,>10,"location_code=""SDN""
+location_name=""Sudan""
+admin1_code=""SD18""
+admin1_name=""West Kordofan""
+population > 0.0
+gender not null
+age_range not null",FALSE,TRUE,"TOTAL_COUNT>10; 
+ALL_HAVE_PROPERTIES[location_code, location_name, gender, age_range, resource_hdx_id, reference_period_start];
+ALL_VERIFY_COMPARISON[population>0];
+ALL_VERIFY_COMPARISON[location_code=""SDN""];
+ALL_VERIFY_COMPARISON[location_name=""Sudan""];
+ALL_VERIFY_COMPARISON[admin1_code=""SD18""];
+ALL_VERIFY_COMPARISON[admin1_name=""West Kordofan""];",also checking resource link
+poverty-rate,pr-default,list of poverty rate records,,/api/v1/population-social/poverty-rate,full page,"location_code not null
+location_name not null
+resource_hdx_id not null
+reference_period_start not null",TRUE,TRUE,"TOTAL_COUNT>50; 
+ALL_HAVE_PROPERTIES[location_code, location_name, resource_hdx_id, reference_period_start];",
+poverty-rate,pr-filtered,list of poverty rate records by country code,?location_code=AFG,/api/v1/population-social/poverty-rate?location_code=AFG,>=8,"location_code=""AFG""
+location_name=""Afghanistan""
+mpi in range 0.0..1.0
+headcount_ratio in range 0.0..100.0
+intensity_of_deprivation in range 0.0..100.0
+vulnerable_to_poverty in range 0.0..100.0
+in_severe_poverty in range 0.0..100.0",FALSE,TRUE,"TOTAL_COUNT>7; 
+ALL_HAVE_PROPERTIES[location_code, location_name, resource_hdx_id, reference_period_start];
+ALL_VERIFY_COMPARISON[location_code=""AFG""];
+ALL_VERIFY_COMPARISON[location_name=""Afghanistan""];
+ALL_VERIFY_COMPARISON[mpi>=0];
+ALL_VERIFY_COMPARISON[mpi<=1];
+ALL_VERIFY_COMPARISON[headcount_ratio>=0];
+ALL_VERIFY_COMPARISON[headcount_ratio<=100];
+ALL_VERIFY_COMPARISON[vulnerable_to_poverty>=0];
+ALL_VERIFY_COMPARISON[vulnerable_to_poverty<=100];
+ALL_VERIFY_COMPARISON[in_severe_poverty>=0];
+ALL_VERIFY_COMPARISON[in_severe_poverty<=100];",
+dataset,ds-default,list of datasets,,/api/v1/metadata/dataset,full page,"hdx_id not null
+hdx_stub not null
+hdx_provider_name not null",TRUE,TRUE,"TOTAL_COUNT>50; 
+ALL_HAVE_PROPERTIES[dataset_hdx_id, dataset_hdx_stub, hdx_provider_name];",
+resource,res-default,list of resources,,/api/v1/metadata/resource,full page,"hdx_id not null
+dataset_hdx_id not null
+hapi_updated_date > 2010-01-01
+hapi_updated_date < 2030-01-01",TRUE,TRUE,"TOTAL_COUNT>50; 
+ALL_HAVE_PROPERTIES[resource_hdx_id, dataset_hdx_id];",
+sector,sec-default,list of sectors,,/api/v1/metadata/sector,>= 15,"code not null
+name not null",TRUE,TRUE,"TOTAL_COUNT>14; 
+ALL_HAVE_PROPERTIES[code, name];",
+org-type,ot-default,list of org types,,/api/v1/metadata/org-type,>= 14,"code not null
+description not null",TRUE,TRUE,"TOTAL_COUNT>13; 
+ALL_HAVE_PROPERTIES[code, description];",
+org-type,ot-code,list of org types by code,?code=437,/api/v1/metadata/org-type?code=437,1,"code=""437""
+description=""International NGO""",FALSE,TRUE,"TOTAL_COUNT=1; 
+ALL_HAVE_PROPERTIES[code, description];
+ALL_VERIFY_COMPARISON[code=""437""];
+ALL_VERIFY_COMPARISON[description=""International NGO""];",
+org,org-default,list of organizations,,/api/v1/metadata/org,full page,"acronym not null
+name not null",TRUE,TRUE,"TOTAL_COUNT>50; 
+ALL_HAVE_PROPERTIES[acronym, name];",
+org,org-acronym,list of organizations by acronym,?acronym=IRC,/api/v1/metadata/org?acronym=IRC,1,"acronym=""IRC""
+name=""International Rescue Committee""
+org_type_code=""437""",FALSE,TRUE,"TOTAL_COUNT=1; 
+ALL_HAVE_PROPERTIES[acronym, name];
+ALL_VERIFY_COMPARISON[acronym=""IRC""];
+ALL_VERIFY_COMPARISON[name=""International Rescue Committee""];
+ALL_VERIFY_COMPARISON[org_type_code=""437""];",
+location,loc-default,list of locations,,/api/v1/metadata/location,full page,"code not null
+name not null",TRUE,TRUE,"TOTAL_COUNT>50; 
+ALL_HAVE_PROPERTIES[code, name];",
+location,loc-code,list of locations by code,?code=mli,/api/v1/metadata/location?code=mli,1,"code=""MLI""
+name=""Mali""",FALSE,TRUE,"TOTAL_COUNT=1; 
+ALL_HAVE_PROPERTIES[code, name];
+ALL_VERIFY_COMPARISON[name=""Mali""];
+ALL_VERIFY_COMPARISON[code=""MLI""];",also tests case-insensitivity
+location,loc-name,list of locations by name,?name=Mali,/api/v1/metadata/location?name=Mali,1,"code=""MLI""
+name=""Mali""",FALSE,TRUE,"TOTAL_COUNT=2; 
+ALL_HAVE_PROPERTIES[code, name];",
+admin1,adm1-default,list of adm1,,/api/v1/metadata/admin1,full page,"code not null
+name not null
+location_code not null",TRUE,TRUE,"TOTAL_COUNT>50; 
+ALL_HAVE_PROPERTIES[code, name, location_code];",
+admin1,adm1-loc,list of adm1 by location code,?location_code=AFG,/api/v1/metadata/admin1?location_code=AFG,> 10,"code not null
+name not null
+location_code=""AFG"" in every object",FALSE,TRUE,"TOTAL_COUNT>10; 
+ALL_HAVE_PROPERTIES[code, name, location_code];
+ALL_VERIFY_COMPARISON[location_code=""AFG""];",
+admin1,adm1-code,list of adm1 by code,?code=AF02,/api/v1/metadata/admin1?code=AF02,1,"code=""AF02""
+name=""Kapisa""
+location_code=""AFG""
+location_name=""Afghanistan""",FALSE,TRUE,"TOTAL_COUNT=1; 
+ALL_HAVE_PROPERTIES[code, name, location_code];
+ALL_VERIFY_COMPARISON[location_code=""AFG""];
+ALL_VERIFY_COMPARISON[location_name=""Afghanistan""];
+ALL_VERIFY_COMPARISON[name=""Kapisa""];
+ALL_VERIFY_COMPARISON[code=""AF02""];",
+admin1,adm1-name,list of adm1 by name and location code,?name=Kapisa&location_code=AFG,/api/v1/metadata/admin1?name=Kapisa&location_code=AFG,1,"1 result only
+code=""AF02""
+name=""Kapisa""
+location_code=""AFG""
+location_name=""Afghanistan""",FALSE,TRUE,"TOTAL_COUNT=1; 
+ALL_HAVE_PROPERTIES[code, name, location_code];
+ALL_VERIFY_COMPARISON[location_code=""AFG""];
+ALL_VERIFY_COMPARISON[location_name=""Afghanistan""];
+ALL_VERIFY_COMPARISON[name=""Kapisa""];
+ALL_VERIFY_COMPARISON[code=""AF02""];",
+admin2,adm2-default,list of adm2,,/api/v1/metadata/admin2,,"code not null
+name not null
+location_code not null
+admin1_code not null",TRUE,TRUE,"TOTAL_COUNT>50; 
+ALL_HAVE_PROPERTIES[code, name, location_code, admin1_code];",
+admin2,adm2-loc,list of admin2 filtered by location code,?location_code=AFG,/api/v1/metadata/admin2?location_code=AFG,full page,"location_code=""AFG""
+code starts with ""AF""",FALSE,TRUE,"TOTAL_COUNT>50; 
+ALL_HAVE_PROPERTIES[code, name, location_code, admin1_code];
+ALL_VERIFY_COMPARISON[location_code=""AFG""];",
+admin2,adm2-adm1,list of admin2 filtered by admin1_code,?admin1_code=AF02,/api/v1/metadata/admin2?admin1_code=AF02,>1,"location_code=""AFG""
+admin1_code=""AF02""
+code starts with ""AF""",FALSE,TRUE,"TOTAL_COUNT>1; 
+ALL_HAVE_PROPERTIES[code, name, location_code, admin1_code];
+ALL_VERIFY_COMPARISON[location_code=""AFG""];
+ALL_VERIFY_COMPARISON[admin1_code=""AF02""];",
+wfp_commodity,wc-default,list of wfp-commodities,,/api/v1/metadata/wfp-commodity,full page,"code not null
+category not null
+name not null",TRUE,TRUE,"TOTAL_COUNT>50; 
+ALL_HAVE_PROPERTIES[code, name, category];",
+wfp_market,wm-default,list of wfp markets,,/api/v1/metadata/wfp-market,full page,"code not null
+location_code not null
+lat in range -90.0,90.0
+lon in range -180.0,180.0",TRUE,TRUE,"TOTAL_COUNT>50; 
+ALL_HAVE_PROPERTIES[code, location_code];",
+currency,cur-default,list of currencies,,/api/v1/metadata/currency,full page,"code not null
+name not null",TRUE,TRUE,"TOTAL_COUNT>50; 
+ALL_HAVE_PROPERTIES[code, name];",
+currency,cur-code,list of filtered currency,?code=usd,/api/v1/metadata/currency?code=usd,1,"code=""USD""
+name=""United States dollar""",FALSE,TRUE,"TOTAL_COUNT=1; 
+ALL_HAVE_PROPERTIES[code, name];
+ALL_VERIFY_COMPARISON[code=""USD""];
+ALL_VERIFY_COMPARISON[name=""United States Dollar""];",also tests case-insensitivity
+currency,cur-code,list of filtered currency case isensitive,?code=Usd,/api/v1/metadata/currency?code=Usd,1,"code=""USD""
+name=""United States dollar""",FALSE,TRUE,"TOTAL_COUNT=1; 
+ALL_HAVE_PROPERTIES[code, name];
+ALL_VERIFY_COMPARISON[code=""USD""];
+ALL_VERIFY_COMPARISON[name=""United States Dollar""];",also tests case-insensitivity
+admin1,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,Option 2,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,
+,,,,,,,FALSE,FALSE,,

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -11,44 +11,41 @@ from collections import Counter
 
 # ENDPOINT, Country filter, Full count (2024-08-13), Filtered count
 ENDPOINT_ROUTER_LIST = [
-    ("/api/v1/affected-people/refugees", "HND"),  # , 580074, 9140
-    ("/api/v1/affected-people/humanitarian-needs", "HND"),  # 279811, 2589
-    ("/api/v1/affected-people/idps", ""),
-    ("/api/v1/affected-people/returnees", ""),
-    ("/api/v1/coordination-context/operational-presence", ""),  # 40472,
-    ("/api/v1/coordination-context/funding", ""),  # 434
-    ("/api/v1/coordination-context/conflict-event", "HTI"),  # 1544173, 10081
-    ("/api/v1/coordination-context/national-risk", ""),  # 26,
-    ("/api/v1/food/food-security", ""),  # 119757,
-    ("/api/v1/food/food-price", "HTI"),  # 1094401, 15948
-    ("/api/v1/population-social/population", ""),  # 237100,
-    ("/api/v1/population-social/poverty-rate", ""),  # 630,
-    ("/api/v1/metadata/dataset", ""),  # 167,
-    ("/api/v1/metadata/resource", ""),  # 257,
-    ("/api/v1/metadata/location", ""),  # 250,
-    ("/api/v1/metadata/admin1", ""),  # 455,
-    ("/api/v1/metadata/admin2", ""),  # 5458,
-    ("/api/v1/metadata/currency", ""),  # 128,
-    ("/api/v1/metadata/org", ""),  # 2531,
-    ("/api/v1/metadata/org-type", ""),  # 19,
-    ("/api/v1/metadata/sector", ""),  # 20,
-    ("/api/v1/metadata/wfp-commodity", ""),  # 1101,
-    ("/api/v1/metadata/wfp-market", ""),  # 4141,
-    ("/api/v1/metadata/data-availability", ""),
+    ('/api/v1/affected-people/refugees', 'HND'),  # , 580074, 9140
+    ('/api/v1/affected-people/humanitarian-needs', 'HND'),  # 279811, 2589
+    ('/api/v1/affected-people/idps', ''),
+    ('/api/v1/affected-people/returnees', ''),
+    ('/api/v1/coordination-context/operational-presence', ''),  # 40472,
+    ('/api/v1/coordination-context/funding', ''),  # 434
+    ('/api/v1/coordination-context/conflict-event', 'HTI'),  # 1544173, 10081
+    ('/api/v1/coordination-context/national-risk', ''),  # 26,
+    ('/api/v1/food/food-security', ''),  # 119757,
+    ('/api/v1/food/food-price', 'HTI'),  # 1094401, 15948
+    ('/api/v1/population-social/population', ''),  # 237100,
+    ('/api/v1/population-social/poverty-rate', ''),  # 630,
+    ('/api/v1/metadata/dataset', ''),  # 167,
+    ('/api/v1/metadata/resource', ''),  # 257,
+    ('/api/v1/metadata/location', ''),  # 250,
+    ('/api/v1/metadata/admin1', ''),  # 455,
+    ('/api/v1/metadata/admin2', ''),  # 5458,
+    ('/api/v1/metadata/currency', ''),  # 128,
+    ('/api/v1/metadata/org', ''),  # 2531,
+    ('/api/v1/metadata/org-type', ''),  # 19,
+    ('/api/v1/metadata/sector', ''),  # 20,
+    ('/api/v1/metadata/wfp-commodity', ''),  # 1101,
+    ('/api/v1/metadata/wfp-market', ''),  # 4141,
+    ('/api/v1/metadata/data-availability', ''),
 ]
 
 # BASE_URL = BASE_URL.replace("hapi", "hapi-temporary")
 # BASE_URL = "http://localhost:8844/"
+BASE_URL = 'https://stage.hapi-humdata-org.ahconu.org/'
 
 
 def test_fetch_data_from_hapi_with_paging():
-    theme = "metadata/admin2"
+    theme = 'metadata/admin2'
 
-    query_url = (
-        f"{BASE_URL}api/v1/{theme}?"
-        f"output_format=csv"
-        f"&app_identifier={HAPI_APP_IDENTIFIER}"
-    )
+    query_url = f'{BASE_URL}api/v1/{theme}?output_format=csv&app_identifier={HAPI_APP_IDENTIFIER}'
 
     results_1000 = fetch_data_from_hapi(query_url, limit=1000)
     results_10000 = fetch_data_from_hapi(query_url, limit=10000)
@@ -59,12 +56,12 @@ def test_fetch_data_from_hapi_with_paging():
 
 
 def test_endpoint_list_against_openapi_definition():
-    with request.urlopen(f"{BASE_URL}openapi.json") as openapi_json_url:
+    with request.urlopen(f'{BASE_URL}openapi.json') as openapi_json_url:
         openapi_json = json.load(openapi_json_url)
 
-    openapi_paths = set(list(openapi_json["paths"].keys()))
-    openapi_paths.remove("/api/v1/encode_app_identifier")
-    openapi_paths.remove("/api/v1/util/version")
+    openapi_paths = set(list(openapi_json['paths'].keys()))
+    openapi_paths.remove('/api/v1/encode_app_identifier')
+    openapi_paths.remove('/api/v1/util/version')
 
     endpoint_paths = {x[0] for x in ENDPOINT_ROUTER_LIST}
 
@@ -72,7 +69,7 @@ def test_endpoint_list_against_openapi_definition():
 
 
 @pytest.mark.parametrize(
-    "endpoint_router, country",
+    'endpoint_router, country',
     ENDPOINT_ROUTER_LIST,
     ids=[
         x[0][7:]
@@ -80,20 +77,17 @@ def test_endpoint_list_against_openapi_definition():
     ],
 )
 def test_for_duplicates_all_endpoints_parametrically(endpoint_router, country):
-    if BASE_URL.endswith("/"):
+    if BASE_URL.endswith('/'):
         theme = endpoint_router[0][1:]
     else:
         theme = endpoint_router[0]
 
     query_url = (
-        f"{BASE_URL}{theme}?"
-        f"output_format=csv"
-        f"&location_code={country}"
-        f"&app_identifier={HAPI_APP_IDENTIFIER}"
+        f'{BASE_URL}{theme}?' f'output_format=csv' f'&location_code={country}&app_identifier={HAPI_APP_IDENTIFIER}'
     )
 
-    if "refugees" in query_url:
-        query_url = query_url.replace("location_code", "origin_location_code")
+    if 'refugees' in query_url:
+        query_url = query_url.replace('location_code', 'origin_location_code')
 
     results = fetch_data_from_hapi(query_url, limit=1000)
 

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -13,6 +13,8 @@ from collections import Counter
 ENDPOINT_ROUTER_LIST = [
     ("/api/v1/affected-people/refugees", "HND"),  # , 580074, 9140
     ("/api/v1/affected-people/humanitarian-needs", "HND"),  # 279811, 2589
+    ("/api/v1/affected-people/idps", ""),
+    ("/api/v1/affected-people/returnees", ""),
     ("/api/v1/coordination-context/operational-presence", ""),  # 40472,
     ("/api/v1/coordination-context/funding", ""),  # 434
     ("/api/v1/coordination-context/conflict-event", "HTI"),  # 1544173, 10081

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -37,10 +37,6 @@ ENDPOINT_ROUTER_LIST = [
     ('/api/v1/metadata/data-availability', ''),
 ]
 
-# BASE_URL = BASE_URL.replace("hapi", "hapi-temporary")
-# BASE_URL = "http://localhost:8844/"
-BASE_URL = 'https://stage.hapi-humdata-org.ahconu.org/'
-
 
 def test_fetch_data_from_hapi_with_paging():
     theme = 'metadata/admin2'
@@ -56,6 +52,7 @@ def test_fetch_data_from_hapi_with_paging():
 
 
 def test_endpoint_list_against_openapi_definition():
+    print(f'{BASE_URL}openapi.json', flush=True)
     with request.urlopen(f'{BASE_URL}openapi.json') as openapi_json_url:
         openapi_json = json.load(openapi_json_url)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,9 +16,6 @@ from util.config import (
 from util.requests import download_csv, read_data_from_csv
 from util.rules import parse_rules
 
-# BASE_URL = "http://localhost:8844/"
-BASE_URL = 'https://stage.hapi-humdata-org.ahconu.org/'
-
 
 DOWNLOAD_PATH = 'tests.csv'
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+import os
 from io import StringIO
 import requests
 import pytest
@@ -12,47 +13,47 @@ from util.config import (
     HAPI_APP_IDENTIFIER,
 )
 
-# BASE_URL = "http://localhost:8844/"
-
 from util.requests import download_csv, read_data_from_csv
 from util.rules import parse_rules
 
-download_csv(TESTS_SPREADSHEET_URL, "tests.csv")
-data_all_columns = read_data_from_csv("tests.csv")
-data = [
-    [row[HEADER_DESCRIPTION], row]
-    for row in data_all_columns
-    if row[HEADER_ENABLED] == "TRUE"
-]
+# BASE_URL = "http://localhost:8844/"
+BASE_URL = 'https://stage.hapi-humdata-org.ahconu.org/'
 
 
-@pytest.mark.parametrize("description, test_info", data)
+DOWNLOAD_PATH = 'tests.csv'
+
+# if os.path.exists(DOWNLOAD_PATH):
+#     os.remove(DOWNLOAD_PATH)
+
+download_csv(TESTS_SPREADSHEET_URL, DOWNLOAD_PATH)
+data_all_columns = read_data_from_csv(DOWNLOAD_PATH)
+data = [[row[HEADER_DESCRIPTION], row] for row in data_all_columns if row[HEADER_ENABLED] == 'TRUE']
+
+
+@pytest.mark.parametrize('description, test_info', data)
 def test_json_rest_api(description, test_info):
     rules = parse_rules(test_info[HEADER_RULES])
 
     relative_url = (
-        test_info[HEADER_API_CALL][1:]
-        if test_info[HEADER_API_CALL].startswith("/")
-        else test_info[HEADER_API_CALL]
+        test_info[HEADER_API_CALL][1:] if test_info[HEADER_API_CALL].startswith('/') else test_info[HEADER_API_CALL]
     )
 
-    if "?" in relative_url:
-        relative_url += f"&app_identifier={HAPI_APP_IDENTIFIER}"
+    print(relative_url, flush=True)
+    if '?' in relative_url:
+        relative_url += f'&app_identifier={HAPI_APP_IDENTIFIER}'
     else:
-        relative_url += f"?app_identifier={HAPI_APP_IDENTIFIER}"
-    endpoint_url = f"{BASE_URL}{relative_url}"
+        relative_url += f'?app_identifier={HAPI_APP_IDENTIFIER}'
+    endpoint_url = f'{BASE_URL}{relative_url}'
 
     response = requests.get(endpoint_url)
     response_dict = response.json()
-    object_list = response_dict.get("data", [])
+    object_list = response_dict.get('data', [])
 
-    assert response.status_code == 200, ", url:" + endpoint_url
+    assert response.status_code == 200, ', url:' + endpoint_url
 
     for rule in rules:
-        output_description = rule.description + ", url:" + endpoint_url
-        assert rule.operator(
-            rule.input_list_builder(object_list), rule.value
-        ), output_description
+        output_description = rule.description + ', url:' + endpoint_url
+        assert rule.operator(rule.input_list_builder(object_list), rule.value), output_description
         # for debug
         # result = rule.operator(rule.input_list_builder(object_list), rule.value)
         # if result:
@@ -62,7 +63,7 @@ def test_json_rest_api(description, test_info):
 
 
 def test_csv_rest_api():
-    endpoint_url = f"{BASE_URL}api/v1/metadata/dataset?output_format=csv&app_identifier={HAPI_APP_IDENTIFIER}"
+    endpoint_url = f'{BASE_URL}api/v1/metadata/dataset?output_format=csv&app_identifier={HAPI_APP_IDENTIFIER}'
     print(endpoint_url, flush=True)
     response = requests.get(endpoint_url)
 

--- a/util/config.py
+++ b/util/config.py
@@ -1,10 +1,12 @@
 import os
 
 
-BASE_URL = os.getenv("BASE_URL", "https://HAPI_SERVER_URL/")
-HAPI_APP_IDENTIFIER = os.getenv("HAPI_APP_IDENTIFIER", "")
-TESTS_SPREADSHEET_URL = os.getenv('TESTS_SPREADSHEET_URL',
-                                  'https://docs.google.com/spreadsheets/d/e/2PACX-1vSfC6zhjjg1MmwoBV2swtKt3mIseFLkzwHgsdJkt6E7wyGW0JdgoV_sbQhlk1CFp8BIt4cJ5-_lKKn9/pub?gid=1213905081&single=true&output=csv')
+BASE_URL = os.getenv('BASE_URL', 'https://HAPI_SERVER_URL/')
+HAPI_APP_IDENTIFIER = os.getenv('HAPI_APP_IDENTIFIER', '')
+TESTS_SPREADSHEET_URL = os.getenv(
+    'TESTS_SPREADSHEET_URL',
+    'https://docs.google.com/spreadsheets/d/e/2PACX-1vSfC6zhjjg1MmwoBV2swtKt3mIseFLkzwHgsdJkt6E7wyGW0JdgoV_sbQhlk1CFp8BIt4cJ5-_lKKn9/pub?gid=1213905081&single=true&output=csv',
+)
 
 HEADER_API_CALL = 'API call'
 HEADER_RULES = 'Rules'

--- a/util/requests.py
+++ b/util/requests.py
@@ -10,7 +10,7 @@ def download_csv(url: str, path: str):
     Download a CSV file from the given URL and save it to the given path
     """
     response = requests.get(url, timeout=50)
-    with open(path, "wb") as mapping_file:
+    with open(path, 'wb') as mapping_file:
         mapping_file.write(response.content)
 
 
@@ -19,7 +19,7 @@ def read_data_from_csv(csv_file_path):
     Read data from a CSV file and return the header and data rows
     """
     data = []
-    with open(csv_file_path, "r") as csv_file:
+    with open(csv_file_path, 'r') as csv_file:
         reader = csv.DictReader(csv_file)
 
         for row in reader:
@@ -39,7 +39,7 @@ def fetch_data_from_hapi(query_url, limit=1000):
     - list: A list of fetched results.
     """
 
-    if "encode_app_identifier" in query_url:
+    if 'encode_app_identifier' in query_url:
         with request.urlopen(query_url) as response:
             json_response = json.loads(response.read())
 
@@ -51,21 +51,21 @@ def fetch_data_from_hapi(query_url, limit=1000):
     t0 = time.time()
     while True:
         offset = idx * limit
-        url = f"{query_url}&offset={offset}&limit={limit}"
+        url = f'{query_url}&offset={offset}&limit={limit}'
 
         with request.urlopen(url) as response:
-            print(f"Getting results {offset} to {offset+limit-1}")
-            print(f"{url}", flush=True)
+            print(f'Getting results {offset} to {offset+limit-1}')
+            print(f'{url}', flush=True)
             encoding = response.headers.get_content_charset()
 
             # print(response.headers, flush=True)
-            if "output_format=json" in query_url:
+            if 'output_format=json' in query_url:
                 json_response = json.loads(response.read())
 
-                results.extend(json_response["data"])
+                results.extend(json_response['data'])
                 # If the returned results are less than the limit,
                 # it's the last page
-                if len(json_response["data"]) < limit:
+                if len(json_response['data']) < limit:
                     break
             else:
                 raw = response.read().decode(encoding)
@@ -80,5 +80,5 @@ def fetch_data_from_hapi(query_url, limit=1000):
                     break
         idx += 1
 
-    print(f"Download took {time.time()-t0:0.2f} seconds", flush=True)
+    print(f'Download took {time.time()-t0:0.2f} seconds', flush=True)
     return results

--- a/util/rules.py
+++ b/util/rules.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, List, Callable, Set
 
+
 class RuleType(Enum):
     TOTAL_COUNT = 'TOTAL_COUNT'
     ALL_HAVE_PROPERTIES = 'ALL_HAVE_PROPERTIES'
@@ -13,7 +14,7 @@ class Rule:
     type: RuleType
 
     input_list_builder: Callable[[List], List]
-    
+
     operator: Callable[[List], bool]
     description: str
     value: Any
@@ -23,30 +24,46 @@ def parse_rules(rules_text) -> List[Rule]:
     rules = []
     for rule_str in rules_text.split(';'):
         rule_str = rule_str.strip()
-        
+
         if rule_str.startswith(RuleType.TOTAL_COUNT.value):
             rule_type = RuleType.TOTAL_COUNT
             rule_input_list_builder = total_count_input_builder
-            rule_body = rule_str[len(RuleType.TOTAL_COUNT.value):].strip()
+            rule_body = rule_str[len(RuleType.TOTAL_COUNT.value) :].strip()
             rule_operator, rule_value, rule_description = _comparison_parser(rule_body, 'Total count', rule_str)
-            rules.append(Rule(type=rule_type, input_list_builder=rule_input_list_builder, operator=rule_operator, value=rule_value, description=rule_description))
+            rules.append(
+                Rule(
+                    type=rule_type,
+                    input_list_builder=rule_input_list_builder,
+                    operator=rule_operator,
+                    value=rule_value,
+                    description=rule_description,
+                )
+            )
 
         elif rule_str.startswith(RuleType.ALL_VERIFY_COMPARISON.value):
             rule_type = RuleType.ALL_VERIFY_COMPARISON
-            rule_body = rule_str[len(RuleType.ALL_VERIFY_COMPARISON.value):].strip()
+            rule_body = rule_str[len(RuleType.ALL_VERIFY_COMPARISON.value) :].strip()
             if not (rule_body.startswith('[') and rule_body.endswith(']')):
                 raise ValueError(f'Invalid rule: {rule_str}')
             rule_body = rule_body[1:-1].strip()
-            property = rule_body.replace('>','=').replace('<', '=').split('=')[0].strip()
+            property = rule_body.replace('>', '=').replace('<', '=').split('=')[0].strip()
             rule_input_list_builder = lambda data, p=property: [item[p] for item in data]
 
-            rule_body = rule_body[len(property):].strip()
+            rule_body = rule_body[len(property) :].strip()
             rule_operator, rule_value, rule_description = _comparison_parser(rule_body, property, rule_str)
-            rules.append(Rule(type=rule_type, input_list_builder=rule_input_list_builder, operator=rule_operator, value=rule_value, description=rule_description))
+            rules.append(
+                Rule(
+                    type=rule_type,
+                    input_list_builder=rule_input_list_builder,
+                    operator=rule_operator,
+                    value=rule_value,
+                    description=rule_description,
+                )
+            )
 
-        elif rule_str.startswith("ALL_HAVE_PROPERTIES"):
+        elif rule_str.startswith('ALL_HAVE_PROPERTIES'):
             rule_type = RuleType.ALL_HAVE_PROPERTIES
-            rule_body = rule_str[len(RuleType.ALL_HAVE_PROPERTIES.value):].strip()
+            rule_body = rule_str[len(RuleType.ALL_HAVE_PROPERTIES.value) :].strip()
             if not (rule_body.startswith('[') and rule_body.endswith(']')):
                 raise ValueError(f'Invalid rule: {rule_str}')
             rule_body = rule_body[1:-1].strip()
@@ -56,14 +73,22 @@ def parse_rules(rules_text) -> List[Rule]:
             fields = set([field.strip() for field in rule_body.split(',')])
             rule_operator = all_have_properties_operator
             rule_description = f'All items should have the following properties: {fields}'
-            rules.append(Rule(type=rule_type, input_list_builder=rule_input_list_builder, operator=rule_operator, value=fields, description=rule_description))
+            rules.append(
+                Rule(
+                    type=rule_type,
+                    input_list_builder=rule_input_list_builder,
+                    operator=rule_operator,
+                    value=fields,
+                    description=rule_description,
+                )
+            )
         elif rule_str:
             raise ValueError(f'Invalid rule: {rule_str}')
     return rules
-            
+
 
 def _comparison_parser(rule_body, comparison_subject, entire_rule):
-    '''
+    """
     Parse a comparison rule
 
 
@@ -82,7 +107,7 @@ def _comparison_parser(rule_body, comparison_subject, entire_rule):
         The operator function to be used in the comparison
     rule_description : str
         A description of the rule
-    '''
+    """
     if rule_body.startswith('='):
         rule_operator = equality_operator
         rule_value = rule_body[1:].strip()
@@ -111,7 +136,7 @@ def _comparison_parser(rule_body, comparison_subject, entire_rule):
     else:
         raise ValueError(f'Invalid rule: {entire_rule}')
     return rule_operator, rule_value, rule_description
-    
+
 
 def total_count_input_builder(data: List) -> List:
     return [len(data)]
@@ -130,6 +155,7 @@ def greater_than_operator(input_list: List, value: int) -> bool:
             return False
     return True
 
+
 def greater_equal_than_operator(input_list: List, value: int) -> bool:
     try:
         for item in input_list:
@@ -147,18 +173,23 @@ def less_than_operator(input_list: List, value: int) -> bool:
             return False
     return True
 
+
 def less_equal_than_operator(input_list: List, value: int) -> bool:
     for item in input_list:
         if item is None or item > value:
             return False
     return True
 
+
 def all_have_properties_operator(input_list: List, fields: Set) -> bool:
     for item in input_list:
         item_keys = set(item.keys())
         if not fields.issubset(item_keys):
+            print(f'Field does not exist: {item_keys - fields}', flush=True)
+            print(f'Extra fields: {fields - item_keys}', flush=True)
             return False
         for field in fields:
             if item[field] is None or item[field] == '':
+                print(f'Field is empty: {field}', flush=True)
                 return False
     return True


### PR DESCRIPTION
This PR updates the smoke tests for HAPI, adding the idps and returnees endpoints. In addition new tests for the data-availability endpoint are added.

The downloaded test specification file - `tests.csv` - is now committed to the repo.

Linting configuration similar to that used in the `hdx-hapi` repo have been added. The main effect of this change is that double quotes are replaced with single quotes.

A small amount of developer documentation has been added. 

These tests should pass against `stage` but fail against other instances of HAPI.